### PR TITLE
Do not fail if Kowalski didn't initialise

### DIFF
--- a/planobs/api.py
+++ b/planobs/api.py
@@ -227,4 +227,7 @@ class Queue:
         """
         Close the connection
         """
-        self.kowalski.close()
+        try:
+            self.kowalski.close()
+        except AttributeError:
+            pass


### PR DESCRIPTION
If you have no kowalski token set, then when you try __del__ of Queue, it'll raise an AttributeError because you haven't completed the __init__ function of Queue yet. This PR catches the AttributeError, leaving only the original planobs.api.APIError 