### PR TITLE
Handle too short observation windows.

### DIFF
--- a/planobs/gcn_parser.py
+++ b/planobs/gcn_parser.py
@@ -219,7 +219,7 @@ def parse_radec(searchstring: str) -> Tuple[float, Optional[float], Optional[flo
     else:
         raise ParsingError(f"Could not parse GCN RA and Dec")
 
-    logger.debug(pos, pos_upper, pos_lower)
+    logger.debug((pos, pos_upper, pos_lower))
 
     return pos, pos_upper, pos_lower
 
@@ -241,7 +241,7 @@ def parse_latest_gcn_notice() -> dict:
     energy = latest["OBSERVATION"]["Energy"][0]
     arrivaltime = Time(f"20{date} {obstime}")
 
-    logger.debug(ra, dec, arrivaltime, revision)
+    logger.debug((ra, dec, arrivaltime, revision))
 
     return {
         "ra": ra,

--- a/planobs/plan.py
+++ b/planobs/plan.py
@@ -272,6 +272,7 @@ class PlanObservation:
             self.rejection_reason = "airmass"
 
         obs_time_minutes = len(bands) * self.observationlength / 60 + (len(bands) - 1) * self.separation_time
+        logger.debug(f"require {obs_time_minutes} minutes, {len(times_included)} available")
         if len(times_included) < obs_time_minutes:
             self.observable = False
             self.rejection_reason = "not enough observation time"
@@ -316,6 +317,7 @@ class PlanObservation:
 
                 # Create two blocks, separated by self.separation_time minutes
                 divider = int(len(times_included) / 2)
+                logger.debug(f"divider is {divider}")
                 obsblock_1 = times_included[0 : divider - self.separation_time]
                 obsblock_2 = times_included[divider + self.separation_time :]
 
@@ -325,6 +327,8 @@ class PlanObservation:
                 else:
                     g_band_obsblock = obsblock_2
                     r_band_obsblock = obsblock_1
+
+                logger.debug(f"g: {len(g_band_obsblock)} min, r: {len(r_band_obsblock)} min")
 
                 self.g_band_recommended_time_start = utils.round_time(
                     g_band_obsblock[0]

--- a/planobs/plan.py
+++ b/planobs/plan.py
@@ -202,8 +202,10 @@ class PlanObservation:
         ]
 
         # Obtain moon coordinates at Palomar for the full time window (default: 24 hours from running the script)
+        # later we will implicitly assume the time steps to be 1 minute so make sure that is the case
+        time_step = int(self.obswindow * 60)
         times = Time(
-            self.start_obswindow + np.linspace(0, self.obswindow, 1440) * u.hour
+            self.start_obswindow + np.linspace(0, self.obswindow, time_step) * u.hour
         )
 
         moon_times = Time(

--- a/planobs/plan.py
+++ b/planobs/plan.py
@@ -651,6 +651,7 @@ class PlanObservation:
             outpath_pdf = os.path.join(
                 self.name, f"{self.name}_airmass_{self.site.name}.pdf"
             )
+        logger.info(f"Saving plot to {outpath_png}")
         plt.savefig(outpath_png, dpi=300, bbox_inches="tight")
         plt.savefig(outpath_pdf, bbox_inches="tight")
 


### PR DESCRIPTION
Check if the time required by observation length and separation time fits into the available time above required airmass.
If not, save `not enough observation time` as rejection reason.
Add `separation_time` in minutes as parameter to `PlanObservation`.
Fixes #96 