### PR TITLE
Make GCN parser read sender with only mail address

### DIFF
--- a/planobs/gcn_parser.py
+++ b/planobs/gcn_parser.py
@@ -142,8 +142,14 @@ def parse_gcn_circular(gcn_number: int) -> GCN_Info:
     submitter = res_json.get("submitter")
     body = res_json.get("body")
 
-    base = submitter.split("at")[0].split(" ")
-    author = [x for x in base if x != ""][1]
+    if "at" in submitter:
+        base = submitter.split("at")[0].split(" ")
+        author = [x for x in base if x != ""][1]
+    elif "@" in submitter:
+        author = submitter.split("@")[0]
+    else:
+        logger.warning(f"Could not parse GCN submitter")
+        author = None
 
     name = subject.split(" - ")[0]
 


### PR DESCRIPTION
The GCN parser assumes a sender of the format `Name <mail@adress.com>` but sometimes it's given as only `mail@adress.com`. In that case, just make it parse the part in front of the `@`.